### PR TITLE
arregla liga para desplegar imagen alternativa 

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -50,7 +50,7 @@ const printMovies = (moviesToPrint) => {
 
     movieCard.setAttribute('class', 'movieCard');
     if (movie.Poster === 'N/A') {
-      moviePoster.setAttribute('src', `${'../isrc/assets/poster-placeholder.png'}`);
+      moviePoster.setAttribute('src', `${'../src/assets/poster-placeholder.png'}`);
     } else {
       moviePoster.setAttribute('src', `${movie.Poster}`);
     }


### PR DESCRIPTION
Arregla la URL para desplegar una imagen alternativa si la película mostrada en pantalla no tiene póster